### PR TITLE
Add jsonapi.rb gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ gem 'has_scope'
 
 # A fast JSON:API serializer for Ruby Objects.
 gem 'jsonapi-serializer'
+# provides some features to use jsonapi-serializer easier
+gem 'jsonapi.rb'
 
 # Simple, efficient background processing for Ruby
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,9 @@ GEM
       activesupport (>= 5.0.0)
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
+    jsonapi.rb (2.0.0)
+      jsonapi-serializer
+      rack
     license_finder (7.0.1)
       bundler
       rubyzip (>= 1, < 3)
@@ -344,6 +347,7 @@ DEPENDENCIES
   has_scope
   jbuilder
   jsonapi-serializer
+  jsonapi.rb
   license_finder
   overcommit
   pagy

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Order by the commit I did:
 9. [Pry](https://github.com/pry/pry) ([commit](https://github.com/zakariaf/rails-base-app/commit/fd94d91fda2e28293266b3f210801e8462fad4cb))
 10. [Pagy](https://github.com/ddnexus/pagy) ([commit1](https://github.com/zakariaf/rails-base-app/commit/f5c4839ba05fe8a927bb18e06e89b0fb20f12045)) ([commit2](https://github.com/zakariaf/rails-base-app/commit/090194eb6912a72ec23349afbca1d3e211204769))
 11. [HasScope](https://github.com/heartcombo/has_scope) ([commit](https://github.com/zakariaf/rails-base-app/commit/a1564e9f8ee645b5b6394bc99608d57eef95b830))
-12. [JSON:API serializer](https://github.com/jsonapi-serializer/jsonapi-serializer) ([commit](https://github.com/zakariaf/rails-base-app/commit/c57cb9db2c0df761e48bdae77971d5fd093033bb))
+12. [JSON:API serializer](https://github.com/jsonapi-serializer/jsonapi-serializer) A fast JSON:API serializer for Ruby Objects ([commit](https://github.com/zakariaf/rails-base-app/commit/c57cb9db2c0df761e48bdae77971d5fd093033bb)) and [jsonapi.rb](https://github.com/stas/jsonapi.rb) which provide some features for `jsonapi-serializer` [PR](https://github.com/zakariaf/rails-base-app/pull/9)
 13. [Action Cable](https://guides.rubyonrails.org/action_cable_overview.html) ([commit](https://github.com/zakariaf/rails-base-app/commit/3d6bd4194c3a992c838093bb8c8c7332784cffba))
 14. [Redis](https://redis.io/) ([commit](https://github.com/zakariaf/rails-base-app/commit/3d6bd4194c3a992c838093bb8c8c7332784cffba))
 15. [Sidekiq](https://github.com/mperham/sidekiq) ([commit](https://github.com/zakariaf/rails-base-app/commit/f7b759d9d42ce3444a04978fe2cbfc66cd120250))


### PR DESCRIPTION
Add [jsonapi.rb](https://github.com/stas/jsonapi.rb) gem which adds these features to make `jsonapi-serializer` gem more powerful:


- object serialization (powered by JSON:API Serializer, was fast_jsonapi)
- [error handling](https://jsonapi.org/format/#errors) (parameters, validation, generic errors)
- fetching of the data (support for [includes](https://jsonapi.org/format/#fetching-includes) and [sparse fields](https://jsonapi.org/format/#fetching-sparse-fieldsets))
- [filtering](https://jsonapi.org/format/#fetching-filtering) and [sorting](https://jsonapi.org/format/#fetching-sorting) of the data (powered by Ransack, soft-dependency)
- [pagination](https://jsonapi.org/format/#fetching-pagination) support